### PR TITLE
Extend update_item function

### DIFF
--- a/includes/class-xcore-products.php
+++ b/includes/class-xcore-products.php
@@ -130,13 +130,27 @@ class Xcore_Products extends WC_REST_Products_Controller
         $object = $this->get_object((int)$request['id']);
         if ($object->is_type('variation')) {
             $product = new WC_Product_Variation($request['id']);
-            $product->set_stock_quantity($request['stock_quantity']);
-            $product->set_manage_stock($request['manage_stock']);
-            $product->set_regular_price($request['regular_price']);
-            $product->set_tax_class($request['tax_class']);
-            $product->set_weight($request['weight']);
-            $product->set_catalog_visibility($request['catalog_visibility']);
-            $product->set_backorders($request['backorders']);
+            if(isset($request['stock_quantity'])){
+                $product->set_stock_quantity($request['stock_quantity']);
+            }
+            if(isset($request['manage_stock'])){
+                $product->set_manage_stock($request['manage_stock']);
+            }
+            if(isset($request['regular_price'])){
+                $product->set_regular_price($request['regular_price']);
+            }
+            if(isset($request['tax_class'])){
+                $product->set_tax_class($request['tax_class']);
+            }
+            if(isset($request['weight'])){
+                $product->set_weight($request['weight']);
+            }
+            if(isset($request['catalog_visibility'])){
+                $product->set_catalog_visibility($request['catalog_visibility']);
+            }
+            if(isset($request['backorders'])){
+                $product->set_backorders($request['backorders']);
+            }
             $product->set_stock_status();
             $product->save();
 

--- a/includes/class-xcore-products.php
+++ b/includes/class-xcore-products.php
@@ -132,8 +132,18 @@ class Xcore_Products extends WC_REST_Products_Controller
             $product = new WC_Product_Variation($request['id']);
             $product->set_stock_quantity($request['stock_quantity']);
             $product->set_manage_stock($request['manage_stock']);
+            $product->set_regular_price($request['regular_price']);
+            $product->set_tax_class($request['tax_class']);
+            $product->set_weight($request['weight']);
+            $product->set_catalog_visibility($request['catalog_visibility']);
+            $product->set_backorders($request['backorders']);
             $product->set_stock_status();
             $product->save();
+
+            // trigger an update (for example to let polylang sync products between languages)
+            if(has_action('woocommerce_update_product')){
+                do_action( 'woocommerce_update_product', $product->get_id() );
+            }
 
             return parent::prepare_object_for_response($product, $request);
         }
@@ -155,9 +165,9 @@ class Xcore_Products extends WC_REST_Products_Controller
         $product_id = $wpdb->get_var(
             $wpdb->prepare(
                 "SELECT post_id 
-  				FROM $wpdb->postmeta 
-  				WHERE meta_key='%s' 
-  				AND meta_value='%s'",
+                  FROM $wpdb->postmeta 
+                  WHERE meta_key='%s' 
+                  AND meta_value='%s'",
                 $meta_key,
                 $product_reference
             )


### PR DESCRIPTION
I added a more attributes to be updated on an update_item trigger from dealer4dealer,
I checked what data was available before telling woocommerce to update the product,
And I added an action trigger to tell in my case polylang to sync the product between languages