### PR TITLE
tell woocommerce to include necessary code

### DIFF
--- a/includes/class-xcore.php
+++ b/includes/class-xcore.php
@@ -54,6 +54,7 @@ class Xcore
 
     public function includes()
     {
+        WC()->api->rest_api_includes();
         include_once dirname(__FILE__) . '/class-xcore-products.php';
         include_once dirname(__FILE__) . '/class-xcore-customers.php';
         include_once dirname(__FILE__) . '/class-xcore-orders.php';


### PR DESCRIPTION
I Got the following error:
`wc_rest_products_controller was called incorrectly. Klassen die de WooCommerce/WordPress REST API uitbreiden kunnen alleen tijdens de rest_api_init-actie worden geladen, of moeten handmatig WC()->api->rest_api_includes() oproepen. Backtrace: require('wp-blog-header.php'), require_once('wp-load.php'), require_once('/var/www/staging/lenouveauchef.com/httpdocs/wp-config.php'), require_once('wp-settings.php'), do_action('plugins_loaded'), WP_Hook->do_action, WP_Hook->apply_filters, run_xcore, Xcore::instance, Xcore->__construct, Xcore->includes, include_once('/plugins/woocommerce-xcore-plugin/includes/class-xcore-products.php'), spl_autoload_call, WC_Autoloader->autoload, wc_doing_it_wrong. This message was added in version 3.6.`

So I did what the warning told me, and it solved the problem. I'm not sure if this is the right place, but it does fix the issue.