### PR TITLE
Improve customer list query

### DIFF
--- a/includes/class-xcore-customers.php
+++ b/includes/class-xcore-customers.php
@@ -104,7 +104,7 @@ class Xcore_Customers extends WC_REST_Customers_Controller
                 WHERE meta1.meta_key = 'last_update'
             ) AS meta ON (users.ID = meta.user_id) 
             HAVING date_modified > %s
-            ORDER BY 'date_modified' ASC LIMIT %d
+            ORDER BY date_modified ASC LIMIT %d
 		";
 
         $sql     = $wpdb->prepare($q, array($key, $value, $value, $limit));

--- a/includes/class-xcore-customers.php
+++ b/includes/class-xcore-customers.php
@@ -84,7 +84,8 @@ class Xcore_Customers extends WC_REST_Customers_Controller
 
         $limit = (int)$request['limit'] ?: 50;
 
-        $key   = 'date_modified';
+        $timezoneOffset = wc_timezone_offset();
+
         $value = $request['date_modified'] ?: 0;
         $value = str_ireplace('T', ' ', $value);
 
@@ -94,7 +95,7 @@ class Xcore_Customers extends WC_REST_Customers_Controller
         $q = "
             SELECT ID as id, user_registered as date_created, 
                 CASE 
-                    WHEN meta_value IS NOT NULL THEN FROM_UNIXTIME(meta_value)
+                    WHEN meta_value IS NOT NULL THEN DATE_ADD(FROM_UNIXTIME(meta_value), INTERVAL %s SECOND)
                     ELSE user_registered 
                 END AS date_modified
             FROM {$wp_users_table} AS users 
@@ -107,7 +108,7 @@ class Xcore_Customers extends WC_REST_Customers_Controller
             ORDER BY date_modified ASC LIMIT %d
 		";
 
-        $sql     = $wpdb->prepare($q, array($key, $value, $value, $limit));
+        $sql     = $wpdb->prepare($q, array($timezoneOffset, $value, $limit));
         $results = $wpdb->get_results($sql, ARRAY_A);
 
         foreach ($results as $key => $value) {

--- a/includes/class-xcore-customers.php
+++ b/includes/class-xcore-customers.php
@@ -92,25 +92,19 @@ class Xcore_Customers extends WC_REST_Customers_Controller
         $wp_user_meta   = $wpdb->prefix . 'usermeta';
 
         $q = "
-   		SELECT 
-		ID as id, 		  
-	    user_registered as date_created, 
-	    CASE 
-	    WHEN meta_value IS NOT NULL
-	    THEN meta_value
-	    ELSE user_registered END
-	    AS %s
-		FROM {$wp_users_table}
-			AS users 
-		    LEFT JOIN (
-				SELECT user_id, meta_key, meta1.meta_value
-				FROM {$wp_user_meta} AS meta1 
-		        WHERE meta1.meta_key = 'last_update'
-		        ) as meta on users.ID = meta.user_id 
-			WHERE users.user_registered > %s
-		    OR (FROM_UNIXTIME(meta.meta_value, '%%Y-%%m-%%d %%h:%%i:%%s') > %s)
-	    
-		ORDER BY $key ASC LIMIT %d
+            SELECT ID as id, user_registered as date_created, 
+                CASE 
+                    WHEN meta_value IS NOT NULL THEN FROM_UNIXTIME(meta_value)
+                    ELSE user_registered 
+                END AS date_modified
+            FROM {$wp_users_table} AS users 
+            LEFT JOIN (
+                SELECT user_id, meta_key, meta1.meta_value
+                FROM {$wp_user_meta} AS meta1 
+                WHERE meta1.meta_key = 'last_update'
+            ) AS meta ON (users.ID = meta.user_id) 
+            HAVING date_modified > %s
+            ORDER BY 'date_modified' ASC LIMIT %d
 		";
 
         $sql     = $wpdb->prepare($q, array($key, $value, $value, $limit));

--- a/includes/class-xcore-customers.php
+++ b/includes/class-xcore-customers.php
@@ -84,8 +84,6 @@ class Xcore_Customers extends WC_REST_Customers_Controller
 
         $limit = (int)$request['limit'] ?: 50;
 
-        $timezoneOffset = wc_timezone_offset();
-
         $value = $request['date_modified'] ?: 0;
         $value = str_ireplace('T', ' ', $value);
 
@@ -95,7 +93,7 @@ class Xcore_Customers extends WC_REST_Customers_Controller
         $q = "
             SELECT ID as id, user_registered as date_created, 
                 CASE 
-                    WHEN meta_value IS NOT NULL THEN DATE_ADD(FROM_UNIXTIME(meta_value), INTERVAL %s SECOND)
+                    WHEN meta_value IS NOT NULL THEN FROM_UNIXTIME(meta_value)
                     ELSE user_registered 
                 END AS date_modified
             FROM {$wp_users_table} AS users 
@@ -108,13 +106,9 @@ class Xcore_Customers extends WC_REST_Customers_Controller
             ORDER BY date_modified ASC LIMIT %d
 		";
 
-        $sql     = $wpdb->prepare($q, array($timezoneOffset, $value, $limit));
+        $sql     = $wpdb->prepare($q, array($value, $limit));
         $results = $wpdb->get_results($sql, ARRAY_A);
 
-        foreach ($results as $key => $value) {
-            $results[$key]['date_created'] = $value['date_created'];
-            $results[$key]['date_modified'] = $this->_xcoreHelper->convertDate('date_modified', $value['date_modified']);
-        }
         return $results;
     }
 


### PR DESCRIPTION
Make the query more readable and use the aliases in the HAVING statement instead of WHERE as this is not possible in the WHERE. Also removed the OR in the HAVING because it's not nescesary and might cause more results in weird situations like user_registered value being in the future..