### PR TITLE
Release 1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Tags: woocommerce, connect, exact, exact online, xcore, d4d, dealer4dealer
 Requires at least: 4.7.5
 Tested up to: 5.6.0
-Stable tag: 1.9.1
+Stable tag: 1.10.0
 License: The MIT License (MIT)
 
 This module extends the api of Woocommerce and is needed for the usage of the xCore. For more information or support see http://www.dealer4dealer.nl.

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
 		}
 	],
 	"require": {
-		"php" : ">=5.6.0",
-		"woocommerce/woocommerce" : ">=3.3.0"
+		"php" : ">=5.6.0"
 	},
-	"version": "1.9.1"
+	"version": "1.10.0"
 }

--- a/includes/class-xcore-documents.php
+++ b/includes/class-xcore-documents.php
@@ -1,0 +1,294 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+class Xcore_Documents
+{
+    protected static $_instance       = null;
+    public           $version         = '1';
+    public           $namespace       = 'wc-xcore/v1';
+    public           $base            = 'documents';
+    private          $_xcoreHelper    = null;
+    protected        $data            = [
+        'document_id'          => '',
+        'document_type'        => '',
+        'document_description' => '',
+        'date_created'         => '',
+        'order_id'             => null,
+        'customer_id'          => null,
+        'files'                => [],
+    ];
+    private          $processed_files = [];
+    private          $user_id_valid   = false;
+    private          $order_id_valid  = false;
+    private          $required_args   = [
+        'document_id',
+        'document_type',
+        'date_created',
+        'files',
+    ];
+
+    public function __construct($helper)
+    {
+        $this->_xcoreHelper = $helper;
+        $this->init();
+    }
+
+    /**
+     * Register all document routes
+     */
+    public function init()
+    {
+        register_rest_route(
+            $this->namespace,
+            $this->base,
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [$this, 'get_item'],
+                'permission_callback' => '__return_true',
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            $this->base,
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [$this, 'create_item'],
+                'permission_callback' => '__return_true',
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            $this->base . '/(?P<id>[\d]+)',
+            [
+                'methods'             => WP_REST_Server::EDITABLE,
+                'callback'            => [$this, 'update_item'],
+                'permission_callback' => '__return_true',
+            ]
+        );
+    }
+
+    public function get_item($request)
+    {
+        return new WP_Error('501', 'GET not yet implemented', ['status' => '501']);
+    }
+
+    public function create_item($request)
+    {
+        $response = $this->set_data($request);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        if ($file_count = count($this->data['files']) > 1) {
+            return new WP_Error(
+                'xcore_documents_unsupported_file_count',
+                sprintf('Unable to process request, unsupported file count (%s)', $file_count),
+                ['status' => '400']
+            );
+        }
+
+        $this->user_id_valid  = $this->is_user_valid($this->data['customer_id']);
+        $this->order_id_valid = $this->is_order_valid($this->data['order_id']);
+
+        $file_process_result = $this->process_files();
+        if (is_wp_error($file_process_result)) {
+            return $file_process_result;
+        }
+
+        $data     = new stdClass();
+        $data->id = $this->data['document_id'];
+
+        return new WP_REST_Response($data, 200);
+    }
+
+    public function update_item($request)
+    {
+        return new WP_Error('501', 'PUT not yet implemented', ['status' => '501']);
+    }
+
+    private function set_data($request)
+    {
+        $dataKeys = array_keys($this->data);
+
+        foreach ($dataKeys as $key) {
+            $hasParam   = $request->has_param($key);
+            $isRequired = $this->is_required($key);
+            if (!$hasParam) {
+                if ($isRequired) {
+                    return new WP_Error(
+                        'xcore_documents_missing_entity',
+                        sprintf('Unable to process request, missing %s', $key),
+                        ['status' => '404']
+                    );
+                }
+                continue;
+            }
+
+            $value = $request->get_param($key);
+
+            if (!$value && $isRequired) {
+                return new WP_Error(
+                    'xcore_documents_missing_entity_value',
+                    sprintf('Unable to process request, %s has an invalid value (%s)', $key, $value),
+                    ['status' => '404']
+                );
+            }
+            $this->data[$key] = $value;
+        }
+        return true;
+    }
+
+    private function is_required($field)
+    {
+        return in_array($field, $this->required_args);
+    }
+
+    private function process_files()
+    {
+        foreach ($this->data['files'] as $file) {
+            $result = $this->upload_file($file);
+
+            if (!$result || $result['error']) {
+                return new WP_Error(
+                    'xcore_documents_upload_failed',
+                    sprintf(
+                        'Unable to process request, failed to upload document file (%s), error: %s',
+                        $result['original_filename'],
+                        $result['error']
+                    ),
+                    ['status' => '404']
+                );
+            }
+
+            $this->attach_file($result);
+        }
+        return true;
+    }
+
+    private function upload_file($file)
+    {
+        $base64Document    = $file['media_data_base64_encoded'];
+        $filename          = $this->generateFilename($file);
+        $documentData      = base64_decode($base64Document);
+        $filenameSanitized = sanitize_file_name($filename);
+        $date              = date("Y/m", strtotime($this->data['date_created']));
+
+        $fileUpload                         = wp_upload_bits($filenameSanitized, null, $documentData, $date);
+        $fileUpload['document_id']          = $this->data['document_id'];
+        $fileUpload['document_description'] = $this->data['document_description'];
+        $fileUpload['original_filename']    = $file['original_filename'];
+
+        return $fileUpload;
+    }
+
+    private function attach_file($file)
+    {
+        if (!$this->check_file($file)) {
+            return false;
+        }
+
+        if ($this->user_id_valid) {
+            $this->attach($file, 'customer');
+        }
+
+        if ($this->order_id_valid) {
+            $this->attach($file, 'order');
+        }
+
+        return true;
+    }
+
+    private function check_file($file)
+    {
+        if ($file['error']) {
+            return false;
+        }
+
+        if (!file_exists($file['file'])) {
+            return false;
+        }
+        return true;
+    }
+
+    private function is_user_valid($user_id)
+    {
+        global $wpdb;
+
+        if (!is_numeric($user_id)) {
+            return false;
+        }
+
+        if (wp_cache_get($user_id, 'users')) {
+            return true;
+        }
+
+        if ($wpdb->get_var($wpdb->prepare("SELECT EXISTS (SELECT 1 FROM $wpdb->users WHERE ID = %d)", $user_id))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function is_order_valid($order_id)
+    {
+        global $wpdb;
+        if (!is_numeric($order_id)) {
+            return false;
+        }
+
+        if ($wpdb->get_var($wpdb->prepare("SELECT EXISTS (SELECT 1 FROM $wpdb->posts WHERE ID = %d)", $order_id))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function attach($file, $type)
+    {
+        $meta_key        = sprintf('xcore_%s', $this->data['document_type']);
+        $document_id     = $this->data['document_id'];
+        $id              = ($type == 'customer') ? $this->data['customer_id'] : $this->data['order_id'];
+        $args['files'][] = $file;
+
+        $this->add_meta_data($id, $type, $args, $meta_key, $document_id);
+    }
+
+    private function add_meta_data($id, $type, $data, $meta_key, $document_id)
+    {
+        $meta_type   = ($type == 'customer') ? 'user' : 'post';
+        $currentMeta = get_metadata($meta_type, $id, $meta_key, true);
+
+        if ($currentMeta === false) {
+            return;
+        }
+
+        if (empty($currentMeta)) {
+            add_metadata($meta_type, $id, $meta_key, $data, true);
+            return;
+        }
+
+        if (!isset($currentMeta['files'])) {
+            update_metadata($meta_type, $id, $meta_key, $data, $currentMeta);
+            return;
+        }
+
+        if (isset($currentMeta['files']) && array_search($document_id, array_column($currentMeta['files'], 'document_id')) === false) {
+            $metaFiles = $currentMeta;
+            array_push($metaFiles['files'], $data['files'][0]);
+            update_metadata($meta_type, $id, $meta_key, $metaFiles, $currentMeta);
+        }
+    }
+
+    private function generateFilename($file)
+    {
+        $fileExtension = $file['file_extension'];
+        $documentType  = $this->data['document_type'];
+        $documentId    = $this->data['document_id'];
+
+        return sprintf('%s_%s.%s', $documentType, $documentId, $fileExtension);
+    }
+}

--- a/includes/class-xcore-products.php
+++ b/includes/class-xcore-products.php
@@ -25,131 +25,136 @@ class Xcore_Products extends WC_REST_Products_Controller
         register_rest_route(
             $this->namespace,
             $this->base,
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'get_items'),
-                'permission_callback' => array($this, 'get_items_permissions_check'),
+                'callback'            => [$this, 'get_items'],
+                'permission_callback' => [$this, 'get_items_permissions_check'],
                 'args'                => $this->get_collection_params(),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base,
-            array(
+            [
                 'methods'             => WP_REST_Server::CREATABLE,
-                'callback'            => array($this, 'create_item'),
-                'permission_callback' => array($this, 'create_item_permissions_check'),
+                'callback'            => [$this, 'create_item'],
+                'permission_callback' => [$this, 'create_item_permissions_check'],
                 'args'                => $this->get_endpoint_args_for_item_schema(WP_REST_Server::CREATABLE),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base,
-            array(
+            [
                 'methods'             => WP_REST_Server::EDITABLE,
-                'callback'            => array($this, 'update_item'),
-                'permission_callback' => array($this, 'update_item_permissions_check'),
+                'callback'            => [$this, 'update_item'],
+                'permission_callback' => [$this, 'update_item_permissions_check'],
                 'args'                => $this->get_endpoint_args_for_item_schema(WP_REST_Server::EDITABLE),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base . '/batch',
-            array(
+            [
                 'methods'             => WP_REST_Server::EDITABLE,
-                'callback'            => array($this, 'batch_items'),
-                'permission_callback' => array($this, 'batch_items_permissions_check'),
+                'callback'            => [$this, 'batch_items'],
+                'permission_callback' => [$this, 'batch_items_permissions_check'],
                 'args'                => $this->get_endpoint_args_for_item_schema(WP_REST_Server::EDITABLE),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base . '/(?P<id>[\d]+)',
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'get_item'),
-                'permission_callback' => array($this, 'get_item_permissions_check'),
+                'callback'            => [$this, 'get_item'],
+                'permission_callback' => [$this, 'get_item_permissions_check'],
                 'args'                => $this->get_collection_params(),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base . '/allby/sku/(?P<sku>[\S]+)',
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'get_all_items'),
-                'permission_callback' => array($this, 'get_item_permissions_check'),
+                'callback'            => [$this, 'get_all_items'],
+                'permission_callback' => [$this, 'get_item_permissions_check'],
                 'args'                => $this->get_collection_params(),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base . '/search',
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'search_item'),
-                'permission_callback' => array($this, 'get_item_permissions_check'),
+                'callback'            => [$this, 'search_item'],
+                'permission_callback' => [$this, 'get_item_permissions_check'],
                 'args'                => $this->get_collection_params(),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base . '/findby/sku/(?P<id>[\S]+)',
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'find_item_by_sku'),
-                'permission_callback' => array($this, 'get_item_permissions_check'),
+                'callback'            => [$this, 'find_item_by_sku'],
+                'permission_callback' => [$this, 'get_item_permissions_check'],
                 'args'                => $this->get_collection_params(),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             $this->base . '/(?P<id>[\d]+)',
-            array(
+            [
                 'methods'             => WP_REST_Server::EDITABLE,
-                'callback'            => array($this, 'update_item'),
-                'permission_callback' => array($this, 'update_item_permissions_check'),
+                'callback'            => [$this, 'update_item'],
+                'permission_callback' => [$this, 'update_item_permissions_check'],
                 'args'                => $this->get_endpoint_args_for_item_schema(WP_REST_Server::EDITABLE),
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             'products/types',
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'get_product_types'),
+                'callback'            => [$this, 'get_product_types'],
                 'permission_callback' => '__return_true',
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             'products/categories',
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'get_product_categories'),
+                'callback'            => [$this, 'get_product_categories'],
                 'permission_callback' => '__return_true',
-            )
+            ]
         );
 
         register_rest_route(
             $this->namespace,
             'products/categories' . '/(?P<id>[\d]+)',
-            array(
+            [
                 'methods'             => WP_REST_Server::READABLE,
-                'callback'            => array($this, 'get_product_category'),
+                'callback'            => [$this, 'get_product_category'],
                 'permission_callback' => '__return_true',
-            )
+            ]
         );
+    }
+
+    public function batch_items($request)
+    {
+        return parent::batch_items($request);
     }
 
     public function create_item($request)
@@ -163,10 +168,12 @@ class Xcore_Products extends WC_REST_Products_Controller
     }
 
     /**
-     * Sadly there's no way of obtaining a list with all available product types, including (custom) variations. This allows
-     * us to bypass the problem if a customer wants to process (custom) variations as well, without impacting performance.
+     * Sadly there's no way of obtaining a list with all available product types, including (custom) variations.
+     * This allows us to bypass the problem if a customer wants to process (custom) variations as well, without
+     * impacting performance.
      *
      * @param WP_REST_Request $request
+     *
      * @return WP_Error|WP_REST_Response
      */
 
@@ -181,7 +188,6 @@ class Xcore_Products extends WC_REST_Products_Controller
          * I attempted to use the Xcore_Product_Variations::get_items() when dealing with variations, but I noticed
          * (which I should have known had I read the API documention concerning available variation properties) some
          * key attributes are missing when using it (such as type).
-         *
          * To avoid missing out on data (added by woocommerce or by any other plug-in) and lose the ability to process
          * specific custom product types, we should leave it as is.
          */
@@ -201,6 +207,7 @@ class Xcore_Products extends WC_REST_Products_Controller
      * Returns an array with item information
      *
      * @param WP_REST_Request $request Full data about the request.
+     *
      * @return array
      */
     public function get_items($request)
@@ -218,19 +225,20 @@ class Xcore_Products extends WC_REST_Products_Controller
         }
 
         $products = new WP_Query(
-            array(
+            [
                 'numberposts'    => -1,
                 'post_type'      => $product_only ? ['product'] : ['product', 'product_variation'],
                 'posts_per_page' => $limit,
                 'orderby'        => 'post_modified',
                 'order'          => 'ASC',
-                'date_query'     => array(
-                    array(
-                        'column' => 'post_modified_gmt',
-                        'after'  => $date
-                    )
-                )
-            )
+                'date_query'     => [
+                    [
+                        'column'    => 'post_modified_gmt',
+                        'after'     => $date,
+                        'inclusive' => true,
+                    ],
+                ],
+            ]
         );
 
         $result = [];
@@ -252,7 +260,7 @@ class Xcore_Products extends WC_REST_Products_Controller
     public function get_all_items($request)
     {
         if (!isset($request['sku'])) {
-            return new WP_Error('404', 'No SKU set', array('status' => '404'));
+            return new WP_Error('404', 'No SKU set', ['status' => '404']);
         }
 
         return parent::get_items($request);
@@ -260,6 +268,7 @@ class Xcore_Products extends WC_REST_Products_Controller
 
     /**
      * @param WP_REST_Request $request
+     *
      * @return WP_Error|WP_REST_Response
      */
     public function update_item($request)
@@ -267,7 +276,13 @@ class Xcore_Products extends WC_REST_Products_Controller
         $object = $this->get_object((int)$request['id']);
 
         if (!$object) {
-            return new WP_Error('404', 'No item found with ID: ' . $request['id'], array('status' => '404'));
+            return new WP_Error('404', 'No item found with ID: ' . $request['id'], ['status' => '404']);
+        }
+
+        $isVariation = $object->is_type('variation');
+
+        if (isset($request['stock_quantity'])) {
+            return $this->updateStock($request, $isVariation);
         }
 
         $file = $this->processMedia($request);
@@ -296,6 +311,7 @@ class Xcore_Products extends WC_REST_Products_Controller
 
     /**
      * @param $request
+     *
      * @return WP_Error|WP_REST_Response
      */
     public function search_item($request)
@@ -315,11 +331,12 @@ class Xcore_Products extends WC_REST_Products_Controller
             }
             return $result;
         }
-        return new WP_Error('404', 'No item found with SKU: ' . $sku, array('status' => '404'));
+        return new WP_Error('404', 'No item found with SKU: ' . $sku, ['status' => '404']);
     }
 
     /**
      * @param $request
+     *
      * @return WP_Error|WP_REST_Response
      */
     public function find_item_by_sku($request)
@@ -328,7 +345,7 @@ class Xcore_Products extends WC_REST_Products_Controller
         $product_id        = wc_get_product_id_by_sku($product_reference);
 
         if (!$product_id) {
-            return new WP_Error('404', 'No item found with SKU: ' . $product_reference, array('status' => '404'));
+            return new WP_Error('404', 'No item found with SKU: ' . $product_reference, ['status' => '404']);
         }
 
         $request['id'] = $product_id;
@@ -337,6 +354,7 @@ class Xcore_Products extends WC_REST_Products_Controller
 
     /**
      * @param WP_REST_Request $request
+     *
      * @return array
      */
     public function get_product_types($request)
@@ -346,6 +364,7 @@ class Xcore_Products extends WC_REST_Products_Controller
 
     /**
      * @param $request
+     *
      * @return mixed|void
      */
     public function get_product_categories($request)
@@ -354,12 +373,12 @@ class Xcore_Products extends WC_REST_Products_Controller
         $order      = 'asc';
         $hide_empty = false;
 
-        $cat_args = array(
+        $cat_args = [
             'orderby'    => $orderby,
             'order'      => $order,
             'hide_empty' => $hide_empty,
             'fields'     => 'ids',
-        );
+        ];
 
         $terms = get_terms('product_cat', $cat_args);
 
@@ -372,6 +391,7 @@ class Xcore_Products extends WC_REST_Products_Controller
     /**
      * @param      $request
      * @param null $id
+     *
      * @return array|WP_Error
      */
     public function get_product_category($request, $id = null)
@@ -401,7 +421,9 @@ class Xcore_Products extends WC_REST_Products_Controller
 
             if (is_wp_error($term) || is_null($term)) {
                 throw new WC_REST_Exception(
-                    'woocommerce_api_invalid_product_category_id', __('A product category with the provided ID could not be found', 'woocommerce'), 404
+                    'woocommerce_api_invalid_product_category_id',
+                    __('A product category with the provided ID could not be found', 'woocommerce'),
+                    404
                 );
             }
 
@@ -417,12 +439,17 @@ class Xcore_Products extends WC_REST_Products_Controller
 
             // Get category image
             $image    = '';
-            $image_id = function_exists('get_term_meta') ? get_term_meta($term_id, 'thumbnail_id', true) : get_metadata('woocommerce_term', $term_id, 'thumbnail_id', true);
+            $image_id = function_exists('get_term_meta') ? get_term_meta($term_id, 'thumbnail_id', true) : get_metadata(
+                'woocommerce_term',
+                $term_id,
+                'thumbnail_id',
+                true
+            );
             if ($image_id) {
                 $image = wp_get_attachment_url($image_id);
             }
 
-            $product_category = array(
+            $product_category = [
                 'id'          => $term_id,
                 'name'        => $term->name,
                 'slug'        => $term->slug,
@@ -431,28 +458,12 @@ class Xcore_Products extends WC_REST_Products_Controller
                 'display'     => $display_type ? $display_type : 'default',
                 'image'       => $image ? esc_url($image) : '',
                 'count'       => intval($term->count),
-            );
+            ];
 
-            return array('product_category' => apply_filters('woocommerce_api_product_category_response', $product_category, $id, null, $term, $this));
+            return ['product_category' => apply_filters('woocommerce_api_product_category_response', $product_category, $id, null, $term, $this)];
         } catch (WC_API_Exception $e) {
-            return new WP_Error($e->getErrorCode(), $e->getMessage(), array('status' => $e->getCode()));
+            return new WP_Error($e->getErrorCode(), $e->getMessage(), ['status' => $e->getCode()]);
         }
-    }
-
-    private function processMedia($request)
-    {
-        if (!isset($request['xcore_media'])) {
-            return false;
-        }
-
-        $dirs = wp_get_upload_dir();
-        $file = $this->upload_item_media($request['xcore_media'], $dirs['basedir']);
-
-        if ($file) {
-            return $dirs['baseurl'] . "/" . $file;
-        }
-
-        return false;
     }
 
     public function upload_item_media($media, $uploadBasedir)
@@ -475,6 +486,45 @@ class Xcore_Products extends WC_REST_Products_Controller
                 break;
         }
         return false;
+    }
+
+    public function filter_stock_updates($data, $postarr, $unsanitized_postarr)
+    {
+        if (isset($postarr['post_modified_gmt'])) {
+            $data['post_modified_gmt'] = $postarr['post_modified_gmt'];
+        }
+        return $data;
+    }
+
+    private function processMedia($request)
+    {
+        if (!isset($request['xcore_media'])) {
+            return false;
+        }
+
+        $dirs = wp_get_upload_dir();
+        $file = $this->upload_item_media($request['xcore_media'], $dirs['basedir']);
+
+        if ($file) {
+            return $dirs['baseurl'] . "/" . $file;
+        }
+
+        return false;
+    }
+
+    private function updateStock($request, $isVariation)
+    {
+        add_filter('wp_insert_post_data', [__CLASS__, 'filter_stock_updates'], 10, 3);
+
+        $product = $isVariation ? new WC_Product_Variation($request['id']) : new WC_Product($request['id']);
+        $date    = $product->get_date_modified();
+
+        $product->set_stock_quantity($request['stock_quantity']);
+        $product->set_date_modified((string)$date);
+        $product->save();
+        remove_filter('wp_insert_post_data', [__CLASS__, 'filter_stock_updates']);
+
+        return new WP_REST_Response($request['stock_quantity'], 200);
     }
 
     private function attachFile($file, $request)

--- a/xcore.php
+++ b/xcore.php
@@ -5,7 +5,7 @@ include_once(ABSPATH . 'wp-admin/includes/plugin.php');
    Plugin Name: xCore Rest API extension
    Plugin URI: http://xcore.dealer4dealer.nl
    description: Extend WC Rest API to support xCore requests
-   @Version: 1.9.1
+   @Version: 1.10.0
    @Author: Dealer4Dealer
    Author URI: http://www.dealer4dealer.nl
    Requires at least: 4.7.5


### PR DESCRIPTION
- removed woocommerce requirement from composer file as this was causing issues for some woocommerce parties
- added new document endpoint for syncing pdf invoices
- updating stock will not update the last_modified date to prevent unnecessary product syncs
- we now will include product changes that match the exact date/time we're querying for, to prevent missing out on changes that were done in bulk
- removed some WP data when retrieving shop/plug-in information due to imcompatibility issues with older WP shops